### PR TITLE
Fix link to default template

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,10 +154,10 @@ HTML reporter, provide `--reporters html` as a CLI option.
 | CLI Option  | Description       |
 |-------------|-------------------|
 | `--reporter-html-export <path>` | Specify a path where the output HTML file will be written to disk. If not specified, the file will be written to `newman/` in the current working directory. |
-| `--reporter-html-template <path>` | Specify a path to the custom template which will be used to render the HTML report. This option depends on `--reporter html` and `--reporter-html-export` being present in the run command. If this option is not specified, the [default template](https://github.com/postmanlabs/newman/blob/develop/lib/reporters/html/template-default.hbs) is used |
+| `--reporter-html-template <path>` | Specify a path to the custom template which will be used to render the HTML report. This option depends on `--reporter html` and `--reporter-html-export` being present in the run command. If this option is not specified, the [default template](https://github.com/postmanlabs/newman-reporter-html/blob/develop/lib/template-default.hbs) is used |
 
 Custom templates (currently handlebars only) can be passed to the HTML reporter via `--reporter-html-template <path>` with `--reporters html` and `--reporter-html-export`.
-The [default template](https://github.com/postmanlabs/newman/blob/develop/lib/reporters/html/template-default.hbs) is used in all other cases.
+The [default template](https://github.com/postmanlabs/newman-reporter-html/blob/develop/lib/template-default.hbs) is used in all other cases.
 
 #### JUNIT/XML reporter options
 Newman can output a summary of the collection run to a JUnit compatible XML file. To enable the JUNIT reporter, provide


### PR DESCRIPTION
The html reporter was exported to a separate package